### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: windows-latest


### PR DESCRIPTION
Potential fix for [https://github.com/BoBoBaSs84/BB84.SAU/security/code-scanning/1](https://github.com/BoBoBaSs84/BB84.SAU/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow file `.github/workflows/ci.yml`. Since the workflow only checks out code and runs build/test steps, it does not require write access to repository contents, issues, or pull requests. The minimal required permission is `contents: read`, which allows the workflow to read repository contents but not modify them. The `permissions` block should be added at the top level of the workflow (before `jobs:`), so it applies to all jobs unless overridden. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
